### PR TITLE
Feat: URL Expiry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,7 +1627,6 @@ dependencies = [
  "serde",
  "sled 0.34.7",
  "sled-extensions",
- "time 0.1.43",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,3 @@ rand = "0.8.4"
 sled = "0.34.7"
 sled-extensions = {version="0.2.0", features = ["bincode"]}
 serde = { version = "1.0.117", features = ["derive"] }
-time = "0.1.12"

--- a/src/api/api_utils.rs
+++ b/src/api/api_utils.rs
@@ -1,11 +1,17 @@
-use rocket::{Request, http::Status, response::{Responder, content::Json}};
+use rocket::{
+    http::Status,
+    response::{content::Json, Responder},
+    Request,
+};
 /// Error type for API responses. Possible errors are:
 /// - `NotFound`: The requested resource was not found (404).
 /// - `InternalServerError`: An internal server error occurred (500).
+/// - `BadRequest`: The request was malformed (400).
 #[derive(Debug, Clone)]
 pub enum APIError {
     NotFound,
     InternalServerError,
+    BadRequest,
 }
 
 impl APIError {
@@ -14,6 +20,7 @@ impl APIError {
         match self {
             APIError::NotFound => Status::NotFound,
             APIError::InternalServerError => Status::InternalServerError,
+            APIError::BadRequest => Status::BadRequest,
         }
     }
 }
@@ -22,8 +29,21 @@ impl APIError {
 impl<'r> Responder<'r, 'static> for APIError {
     fn respond_to(self, req: &'r Request<'_>) -> rocket::response::Result<'static> {
         let json_string = match self {
-            APIError::NotFound => format!("{{\"error\":{{\"code\":{},\"message\":\"{}\"}}}}", Status::NotFound.code, Status::NotFound.reason().unwrap()),
-            APIError::InternalServerError => format!("{{\"error\":{{\"code\":{},\"message\":\"{}\"}}}}", Status::InternalServerError.code, Status::InternalServerError.reason().unwrap()),
+            APIError::NotFound => format!(
+                "{{\"error\":{{\"code\":{},\"message\":\"{}\"}}}}",
+                Status::NotFound.code,
+                Status::NotFound.reason().unwrap()
+            ),
+            APIError::InternalServerError => format!(
+                "{{\"error\":{{\"code\":{},\"message\":\"{}\"}}}}",
+                Status::InternalServerError.code,
+                Status::InternalServerError.reason().unwrap()
+            ),
+            APIError::BadRequest => format!(
+                "{{\"error\":{{\"code\":{},\"message\":\"{}\"}}}}",
+                Status::BadRequest.code,
+                Status::BadRequest.reason().unwrap()
+            ),
         };
         Json(json_string).respond_to(&req)
     }

--- a/src/api/api_utils.rs
+++ b/src/api/api_utils.rs
@@ -1,5 +1,7 @@
 use rocket::{Request, http::Status, response::{Responder, content::Json}};
-
+/// Error type for API responses. Possible errors are:
+/// - `NotFound`: The requested resource was not found (404).
+/// - `InternalServerError`: An internal server error occurred (500).
 #[derive(Debug, Clone)]
 pub enum APIError {
     NotFound,
@@ -7,6 +9,7 @@ pub enum APIError {
 }
 
 impl APIError {
+    /// Returns a `rocket::http::Status` for this error.
     pub fn status(&self) -> Status {
         match self {
             APIError::NotFound => Status::NotFound,
@@ -15,6 +18,7 @@ impl APIError {
     }
 }
 
+/// Formats an APIError into a JSON response.
 impl<'r> Responder<'r, 'static> for APIError {
     fn respond_to(self, req: &'r Request<'_>) -> rocket::response::Result<'static> {
         let json_string = match self {

--- a/src/api/links.rs
+++ b/src/api/links.rs
@@ -38,6 +38,9 @@ pub fn create_link(
     db: &State<database::DB>,
     url: Json<database::URL>,
 ) -> Result<Json<database::URL>, APIError> {
+    if url.is_expired() {
+        return Err(APIError::BadRequest);
+    }
     match db.urls.insert(url.code.as_bytes(), url.clone()) {
         Ok(_) => Ok(Json(url.0)),
         Err(_) => Err(APIError::InternalServerError),

--- a/src/api/links.rs
+++ b/src/api/links.rs
@@ -4,12 +4,34 @@ use rocket::State;
 
 use crate::api::api_utils::APIError;
 
+/// API endpoint for fetching URL information.
+/// Request should be sent to `/api/links/<url>`, Where `<url>` is the shortened URL code.
 #[get("/link/<url>")]
 pub fn link_info(db: &State<database::DB>, url: String) -> Result<Json<database::URL>, APIError> {
-    db.get_url(&url)
-        .map(|url| Json(url))
+    db.get_url(&url).map(|url| Json(url))
 }
 
+/// API endpoint for creating a new URL.
+/// Request body should be a JSON object with the following fields:
+/// - url: the URL to shorten
+/// - code: the code to use for the shortened URL
+/// - expiry_time: the time at which the shortened URL should expire, as a UNIX timestamp in milliseconds (optional)
+///
+/// # Example Requests
+/// ```json
+/// {
+///     "code":"short",
+///     "target":"https://example.com",
+/// }
+/// ```
+/// With Expiry Time:
+/// ```json
+/// {
+///     "code":"short",
+///     "target":"https://example.com",
+///     "expiry_time":1568888888
+/// }
+/// ```
 //Test this endpoint: curl -X PUT -H "Content-Type: application/json" -d '{"code":"abc","target":"https://abc.xyz"}' "127.0.0.1:8000/api/link"
 #[put("/link", data = "<url>")]
 pub fn create_link(
@@ -22,6 +44,8 @@ pub fn create_link(
     }
 }
 
+/// API endpoint for deleting a URL.
+/// Request should be sent to `/api/links/<url>`, Where `<url>` is the shortened URL code.
 //Test this endpoint: curl -X DELETE "127.0.0.1:8000/api/link/<link>"
 #[delete("/link/<url>")]
 pub fn delete_link(db: &State<database::DB>, url: String) -> Result<Json<database::URL>, APIError> {

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,5 +1,6 @@
-use core::time;
-use std::time::{SystemTime, UNIX_EPOCH};
+// use core::time;
+// use std::time::{SystemTime, UNIX_EPOCH};
+extern crate time;
 
 use rocket::{
     http::Status,
@@ -19,8 +20,26 @@ impl DB {
         let url = self.urls.get(&code).unwrap();
         if url.is_none() {
             return Err(APIError::NotFound);
+        } else {
+            let url_reference = url.as_ref().unwrap();
+            if !url_reference.expiry_time.is_none() {
+                let expiration_time = url_reference.expiry_time.unwrap();
+                let system_time = time::get_time();
+                let millisec = system_time.sec + system_time.nsec as i64 / 1000 / 1000;
+                if expiration_time as i64 <= millisec {
+                    self.delete_link(&url.unwrap().code);
+                    return Err(APIError::NotFound);
+                }
+            }
         }
         Ok(url.unwrap().clone())
+    }
+    pub fn delete_link(&self, url: &String) -> Result<URL, APIError> {
+        match self.urls.remove(&url) {
+            Ok(None) => Err(APIError::NotFound),
+            Ok(Some(url)) => Ok(url),
+            Err(_) => Err(APIError::InternalServerError),
+        }
     }
 }
 
@@ -41,3 +60,4 @@ impl<'r> Responder<'r, 'static> for URL {
             .ok()
     }
 }
+


### PR DESCRIPTION
Allows the client to create shortlinks that expire.
* Client requests URL to be created with `expiry_time` in the future
* When the URL object is accessed, its `expiry_time` is checked against the current time
  * If the URL is past expiry, it is deleted from the database, and a `404` should be issued
* URLs can have `expiry_time` set to `None`, indicating that they never expire.
* If the `expiry_time` is set to a time that's in the past, a `400` error should be issued.