### PR TITLE
Feat: Url hits

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -76,12 +76,15 @@ impl URL {
                 .duration_since(UNIX_EPOCH)
                 .unwrap()
                 .as_millis();
-            return now > expiration_time;
-        } else if let Some(max_hits) = self.max_hits {
-            if max_hits <= self.num_hits {
-                return true;
-            }
+                if now > expiration_time {
+                    return true;
+                } else if let Some(max_hits) = self.max_hits {
+                    if max_hits <= self.num_hits {
+                        return true;
+                    }
+                }
         }
+        
         return false;
     }
 }


### PR DESCRIPTION
Opening now to keep track of things to-do. Feature is nearly done, but we need to change the way we handle updating hits. Right now it's:
1) Fetch the URL object
2) Update the hit counter
3) Rewrite the URL object

This means that multiple threads accessing and incrementing the hit counter may fail to do so correctly. Instead, we should be utilizing sled's merge feature.